### PR TITLE
Arch Linux

### DIFF
--- a/tchoutchou.sh
+++ b/tchoutchou.sh
@@ -2,7 +2,6 @@ echo "Bienvenue dans tchoutchou le tout premier script ferroviaire de github"
 echo "Nous allons avant tout vérifier que tchoutchou peut se lancer sur ta machine..." 
 
 if [ -f /etc/os-release ]; then
-    # freedesktop.org and systemd
     . /etc/os-release
     OS=$ID
 fi

--- a/tchoutchou.sh
+++ b/tchoutchou.sh
@@ -5,9 +5,8 @@ if [ -f /etc/os-release ]; then
     . /etc/os-release
     OS=$ID
 fi
-
-if [ $OS=debian ]
-then
+if [ "$OS" = "debian" ]; then
+  echo "here"
   if ! [ -f "/usr/games/sl" ]; then
     echo "* le package sl requis pour faire fonctionner ce script"
     echo "* utilise apt install sl pour installer tchoutchou"
@@ -20,8 +19,8 @@ then
   apt install sl -y
 
   exit 1
-elif [ $OS=arch ]
-then
+  fi
+elif [ "$OS" = "arch" ]; then
   if ! [ -f "/bin/sl" ]; then
     echo "* le package sl requis pour faire fonctionner ce script"
     echo "* utilise pacman -S sl pour installer tchoutchou"
@@ -34,8 +33,8 @@ then
   pacman -S --noconfirm sl 
 
   exit 1
+  fi
 fi
-
 clear
 
 echo "! une fois le train lancé, enfoncez CTRL+C pendant quelque seconde pour stoper le train !"
@@ -45,16 +44,14 @@ clear
 echo "Lancement de TchouTchou.sh (édition 🎃 Halloween 🎃 2023, bientot 2024 inchallah)"
 sleep 1
 
-if [ $OS=arch ]
-then
+if [ "$OS" = "arch" ]; then
     for (( ; ; ))
     do
         /bin/sl -e
         /bin/sl -laF -e
     done
     clear
-elif [ $OS=debian ]
-then
+elif [ "$OS" = "debian" ]; then
     for (( ; ; ))
     do
         /usr/games/sl -e

--- a/tchoutchou.sh
+++ b/tchoutchou.sh
@@ -1,16 +1,38 @@
 echo "Bienvenue dans tchoutchou le tout premier script ferroviaire de github" 
 echo "Nous allons avant tout vérifier que tchoutchou peut se lancer sur ta machine..." 
 
-if ! [ -f "/usr/games/sl" ]; then
-  echo "* le package sl requis pour faire fonctionner ce script"
-  echo "* utilise apt install sl pour installer tchoutchou"
+if [ -f /etc/os-release ]; then
+    # freedesktop.org and systemd
+    . /etc/os-release
+    OS=$ID
+fi
 
-  if [[ $EUID -ne 0 ]]; then
-    echo "* Tu dois avoir accès au root afin d'installer le module" 1>&2
-    exit 1
-  fi
+if [ $OS=debian ]
+then
+  if ! [ -f "/usr/games/sl" ]; then
+    echo "* le package sl requis pour faire fonctionner ce script"
+    echo "* utilise apt install sl pour installer tchoutchou"
+  
+    if [[ $EUID -ne 0 ]]; then
+      echo "* Tu dois avoir accès au root afin d'installer le module" 1>&2
+      exit 1
+    fi
 
   apt install sl -y
+
+  exit 1
+elif [ $OS=arch ]
+then
+  if ! [ -f "/bin/sl" ]; then
+    echo "* le package sl requis pour faire fonctionner ce script"
+    echo "* utilise pacman -S sl pour installer tchoutchou"
+  
+    if [[ $EUID -ne 0 ]]; then
+      echo "* Tu dois avoir accès au root afin d'installer le module" 1>&2
+      exit 1
+    fi
+
+  pacman -S --noconfirm sl 
 
   exit 1
 fi
@@ -24,9 +46,20 @@ clear
 echo "Lancement de TchouTchou.sh (édition 🎃 Halloween 🎃 2023, bientot 2024 inchallah)"
 sleep 1
 
-for (( ; ; ))
-do
-   /usr/games/sl -e
-   /usr/games/sl -laF -e
-done
-clear
+if [ $OS=arch ]
+then
+    for (( ; ; ))
+    do
+        /bin/sl -e
+        /bin/sl -laF -e
+    done
+    clear
+elif [ $OS=debian ]
+then
+    for (( ; ; ))
+    do
+        /usr/games/sl -e
+        /usr/games/sl -laF -e
+    done
+    clear
+fi


### PR DESCRIPTION
Votre script ferroviaire est utile, mais il n'est compatible qu'avec les machines sous une base Debian utilisant apt et stockant sl dans /usr/games.
Voici une version différente du script qui détecte si la distribution est basée sur Arch ou Debian et applique les commandes appropriés. 
Merci de bien vouloir accepter ma contribution.

I use Arch btw.